### PR TITLE
Add plan-review slash command for reviewing Claude plans with Codex

### DIFF
--- a/slash_commands/plan-review.md
+++ b/slash_commands/plan-review.md
@@ -14,9 +14,10 @@ allowed-tools: >
 
 ## Task (follow strictly)
 1) First, detect the latest plan file:
-   - `ls -lt ~/.claude/plans/*.md | head -1` (latest plan file)
-   - Read the plan file content
-2) Run `codex review $ARGUMENTS -c hide_agent_reasoning=true` with the plan file to get review feedback.
+   - Run `ls -t ~/.claude/plans/*.md | head -1` to get the latest plan file path
+   - Store the path (e.g., `PLAN_FILE=~/.claude/plans/example.md`)
+   - Read the plan file content using the Read tool
+2) Run `codex review "$PLAN_FILE" $ARGUMENTS -c hide_agent_reasoning=true` to get review feedback on the plan file.
 3) Read the Codex review output and extract actionable feedback:
    - Missing considerations
    - Potential risks or edge cases


### PR DESCRIPTION
## Summary
- Add a new slash command `/plan-review` that uses Codex CLI to review plan files created during Claude's plan mode
- Automatically detects the latest plan file from `~/.claude/plans/`
- Runs Codex review and updates the plan based on actionable feedback

## Test plan
- [ ] Copy `slash_commands/plan-review.md` to `~/.claude/commands/`
- [ ] Create a plan in plan mode
- [ ] Run `/plan-review` and verify Codex reviews the plan and Claude updates it based on feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)