### PR TITLE
Add antipatterns skill with 5 common coding mistakes

### DIFF
--- a/skills/antipatterns/SKILL.md
+++ b/skills/antipatterns/SKILL.md
@@ -35,6 +35,7 @@ The following antipatterns are currently documented:
 | AP-003 | Use collections.abc for generic types | Python/Typing |
 | AP-004 | Reuse existing enums | Code Reuse |
 | AP-005 | Always add unit tests for new features | Testing |
+| AP-006 | Use generic types for input, concrete types for output | Python/Typing |
 
 ## Adding New Antipatterns
 
@@ -77,3 +78,4 @@ All antipattern definitions are stored in:
 - `patterns/AP-003-use-collections-abc.md`
 - `patterns/AP-004-reuse-enums.md`
 - `patterns/AP-005-add-unit-tests.md`
+- `patterns/AP-006-generic-input-concrete-output.md`

--- a/skills/antipatterns/SKILL.md
+++ b/skills/antipatterns/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: antipatterns
+description: This skill should be used automatically during code review and implementation to prevent common coding mistakes and antipatterns. It helps agents avoid known bad practices that have been identified through past experiences.
+version: 1.0.0
+---
+
+# Antipatterns Skill
+
+## Overview
+
+This skill contains a collection of coding antipatterns that agents should avoid. Each antipattern is documented in the `patterns/` directory and should be consulted during code review and implementation tasks.
+
+**When this skill applies:**
+- Code review tasks
+- Writing new code
+- Refactoring existing code
+- Any implementation work
+
+## How to Use
+
+When performing code review or implementation:
+
+1. Review all pattern files in `patterns/` directory
+2. Check if the code being written or reviewed violates any antipattern
+3. If a violation is found, fix it according to the guidance provided
+
+## Current Antipatterns
+
+The following antipatterns are currently documented:
+
+| ID | Pattern | Category |
+|----|---------|----------|
+| AP-001 | Avoid `object` type in Python | Python/Typing |
+| AP-002 | Don't modify pyproject.toml unnecessarily | Configuration |
+| AP-003 | Use collections.abc for generic types | Python/Typing |
+| AP-004 | Reuse existing enums | Code Reuse |
+| AP-005 | Always add unit tests for new features | Testing |
+
+## Adding New Antipatterns
+
+To add a new antipattern:
+
+1. Create a new markdown file in `patterns/` directory
+2. Follow the naming convention: `AP-XXX-short-description.md`
+3. Use the template structure:
+   ```markdown
+   # AP-XXX: Title
+
+   ## Category
+   [Category name]
+
+   ## Description
+   [What the antipattern is]
+
+   ## Why It's Bad
+   [Why this should be avoided]
+
+   ## Correct Approach
+   [How to do it correctly]
+
+   ## Examples
+
+   ### Bad
+   [Code example of the antipattern]
+
+   ### Good
+   [Code example of the correct approach]
+   ```
+
+4. Update this SKILL.md to include the new antipattern in the table above
+
+## Pattern Files
+
+All antipattern definitions are stored in:
+- `patterns/AP-001-avoid-object-type.md`
+- `patterns/AP-002-no-pyproject-modification.md`
+- `patterns/AP-003-use-collections-abc.md`
+- `patterns/AP-004-reuse-enums.md`
+- `patterns/AP-005-add-unit-tests.md`

--- a/skills/antipatterns/patterns/AP-001-avoid-object-type.md
+++ b/skills/antipatterns/patterns/AP-001-avoid-object-type.md
@@ -1,0 +1,47 @@
+# AP-001: Avoid `object` Type in Python
+
+## Category
+Python/Typing
+
+## Description
+Do not use `object` as a type annotation in Python. If you need to represent any type, use `typing.Any` instead.
+
+## Why It's Bad
+- `object` is the base class of all Python classes, but it's not the same as "any type"
+- Using `object` as a type hint is semantically incorrect and can cause type checker confusion
+- `object` has a very limited interface, which doesn't reflect the actual usage when you mean "any type"
+
+## Correct Approach
+When you need to accept any type:
+- Use `typing.Any` to indicate that any type is acceptable
+- Consider if a more specific type or generic type parameter would be more appropriate
+
+## Examples
+
+### Bad
+```python
+def process(data: object) -> object:
+    return data
+
+def store_value(value: object) -> None:
+    self._value = value
+```
+
+### Good
+```python
+from typing import Any
+
+def process(data: Any) -> Any:
+    return data
+
+def store_value(value: Any) -> None:
+    self._value = value
+
+# Or better, use generics if applicable
+from typing import TypeVar
+
+T = TypeVar('T')
+
+def process(data: T) -> T:
+    return data
+```

--- a/skills/antipatterns/patterns/AP-002-no-pyproject-modification.md
+++ b/skills/antipatterns/patterns/AP-002-no-pyproject-modification.md
@@ -1,0 +1,51 @@
+# AP-002: Don't Modify pyproject.toml Unnecessarily
+
+## Category
+Configuration
+
+## Description
+Do not modify `pyproject.toml` without explicit permission. When using suppression syntax like `noqa`, `type: ignore`, or similar, keep the impact as localized as possible.
+
+## Why It's Bad
+- `pyproject.toml` changes affect the entire project
+- Global linter/type checker rule changes can mask real issues
+- Other developers may not be aware of suppressed warnings
+- It can lead to technical debt accumulation
+
+## Correct Approach
+- Use inline suppression comments instead of global configuration changes
+- Scope suppressions to the specific line or block where needed
+- Always include a reason for the suppression
+- If global changes are truly needed, discuss with the team first
+
+## Examples
+
+### Bad
+```toml
+# pyproject.toml
+[tool.ruff]
+ignore = ["E501", "F401"]  # Adding global ignores
+
+[tool.mypy]
+disable_error_code = ["import", "attr-defined"]  # Disabling globally
+```
+
+### Good
+```python
+# In the specific file where suppression is needed
+
+# For a specific line
+from unused_module import something  # noqa: F401 - Required for side effects
+
+# For type checking issues
+result = some_dynamic_call()  # type: ignore[attr-defined] - Dynamic attribute from plugin
+
+# For a specific block
+# fmt: off
+matrix = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+]
+# fmt: on
+```

--- a/skills/antipatterns/patterns/AP-003-use-collections-abc.md
+++ b/skills/antipatterns/patterns/AP-003-use-collections-abc.md
@@ -1,0 +1,57 @@
+# AP-003: Use collections.abc for Generic Types
+
+## Category
+Python/Typing
+
+## Description
+For generic types like `Sequence`, `Mapping`, `Iterable`, `Iterator`, `Callable`, etc., import them from `collections.abc` instead of `typing`.
+
+## Why It's Bad
+- Importing generic types from `typing` is deprecated since Python 3.9
+- The `typing` module versions are maintained only for backward compatibility
+- Using `typing` versions creates inconsistency in modern codebases
+- Future Python versions may remove these from `typing`
+
+## Correct Approach
+Import abstract base classes from `collections.abc`:
+- `Sequence`, `MutableSequence`
+- `Mapping`, `MutableMapping`
+- `Set`, `MutableSet`
+- `Iterable`, `Iterator`
+- `Callable`
+- `Collection`
+- `Container`
+- etc.
+
+## Examples
+
+### Bad
+```python
+from typing import Sequence, Mapping, Iterable, Callable, Iterator
+
+def process_items(items: Sequence[str]) -> Mapping[str, int]:
+    pass
+
+def apply_func(func: Callable[[int], str], items: Iterable[int]) -> Iterator[str]:
+    pass
+```
+
+### Good
+```python
+from collections.abc import Sequence, Mapping, Iterable, Callable, Iterator
+
+def process_items(items: Sequence[str]) -> Mapping[str, int]:
+    pass
+
+def apply_func(func: Callable[[int], str], items: Iterable[int]) -> Iterator[str]:
+    pass
+```
+
+## Note
+For concrete types like `list`, `dict`, `set`, `tuple`, you can use the built-in types directly (since Python 3.9):
+
+```python
+# Good - using built-in types directly
+def process(items: list[str]) -> dict[str, int]:
+    pass
+```

--- a/skills/antipatterns/patterns/AP-004-reuse-enums.md
+++ b/skills/antipatterns/patterns/AP-004-reuse-enums.md
@@ -1,0 +1,68 @@
+# AP-004: Reuse Existing Enums
+
+## Category
+Code Reuse
+
+## Description
+When the codebase already defines an enum for a particular purpose, reuse that existing enum instead of creating a new one with similar or identical values.
+
+## Why It's Bad
+- Duplicate enums create confusion about which one to use
+- Changes to one enum won't be reflected in duplicates
+- Type checking becomes inconsistent across the codebase
+- It violates the DRY (Don't Repeat Yourself) principle
+- Comparison between different enum types will fail even if values match
+
+## Correct Approach
+1. Search the codebase for existing enums before creating new ones
+2. Import and use the existing enum from its original location
+3. If the existing enum needs additional values, extend it properly or discuss with the team
+4. Document where the canonical enum definition lives
+
+## Examples
+
+### Bad
+```python
+# file: services/payment.py
+from enum import Enum
+
+class PaymentStatus(Enum):  # Duplicating existing enum!
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+def process_payment(status: PaymentStatus) -> None:
+    pass
+```
+
+```python
+# file: models/order.py (existing enum)
+from enum import Enum
+
+class OrderPaymentStatus(Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+```
+
+### Good
+```python
+# file: services/payment.py
+from models.order import OrderPaymentStatus
+
+def process_payment(status: OrderPaymentStatus) -> None:
+    pass
+```
+
+## How to Find Existing Enums
+
+Before creating a new enum, search the codebase:
+
+```bash
+# Search for enum definitions
+grep -r "class.*Enum" --include="*.py" .
+grep -r "class.*StrEnum" --include="*.py" .
+
+# Search for specific enum values you need
+grep -r "PENDING\|COMPLETED\|FAILED" --include="*.py" .
+```

--- a/skills/antipatterns/patterns/AP-005-add-unit-tests.md
+++ b/skills/antipatterns/patterns/AP-005-add-unit-tests.md
@@ -1,0 +1,87 @@
+# AP-005: Always Add Unit Tests for New Features
+
+## Category
+Testing
+
+## Description
+When adding new functionality to the codebase, always include corresponding unit tests that verify the new feature works correctly.
+
+## Why It's Bad
+- Untested code is unreliable code
+- Bugs may go unnoticed until production
+- Future refactoring becomes risky without tests
+- Other developers can't verify their changes don't break the feature
+- Code coverage decreases over time
+
+## Correct Approach
+1. Write tests for all new functions, methods, and classes
+2. Test both happy paths and edge cases
+3. Include error handling tests
+4. Follow the existing test structure and conventions in the project
+5. Ensure tests are independent and can run in any order
+
+## Examples
+
+### Bad
+```python
+# file: services/calculator.py
+def calculate_discount(price: float, discount_percent: float) -> float:
+    """Calculate discounted price."""
+    if discount_percent < 0 or discount_percent > 100:
+        raise ValueError("Discount must be between 0 and 100")
+    return price * (1 - discount_percent / 100)
+
+# No tests added!
+```
+
+### Good
+```python
+# file: services/calculator.py
+def calculate_discount(price: float, discount_percent: float) -> float:
+    """Calculate discounted price."""
+    if discount_percent < 0 or discount_percent > 100:
+        raise ValueError("Discount must be between 0 and 100")
+    return price * (1 - discount_percent / 100)
+```
+
+```python
+# file: tests/services/test_calculator.py
+import pytest
+from services.calculator import calculate_discount
+
+
+class TestCalculateDiscount:
+    """Tests for calculate_discount function."""
+
+    def test_calculate_discount_basic(self):
+        """Test basic discount calculation."""
+        assert calculate_discount(100, 10) == 90.0
+
+    def test_calculate_discount_zero_discount(self):
+        """Test with no discount."""
+        assert calculate_discount(100, 0) == 100.0
+
+    def test_calculate_discount_full_discount(self):
+        """Test with 100% discount."""
+        assert calculate_discount(100, 100) == 0.0
+
+    def test_calculate_discount_negative_raises(self):
+        """Test that negative discount raises ValueError."""
+        with pytest.raises(ValueError, match="Discount must be between 0 and 100"):
+            calculate_discount(100, -10)
+
+    def test_calculate_discount_over_100_raises(self):
+        """Test that discount over 100 raises ValueError."""
+        with pytest.raises(ValueError, match="Discount must be between 0 and 100"):
+            calculate_discount(100, 150)
+```
+
+## Test Checklist
+
+When adding new features, ensure you have tests for:
+
+- [ ] Normal/expected inputs (happy path)
+- [ ] Boundary values (min, max, empty)
+- [ ] Invalid inputs (error cases)
+- [ ] Edge cases specific to the feature
+- [ ] Integration with other components (if applicable)

--- a/skills/antipatterns/patterns/AP-006-generic-input-concrete-output.md
+++ b/skills/antipatterns/patterns/AP-006-generic-input-concrete-output.md
@@ -1,0 +1,76 @@
+# AP-006: Use Generic Types for Input, Concrete Types for Output
+
+## Category
+Python/Typing
+
+## Description
+Function parameters (input) should use abstract generic types like `Mapping`, `Sequence`, `Iterable` from `collections.abc`, while return types (output) should use concrete types like `dict`, `list`, `set`.
+
+## Why It's Bad
+- Using concrete types for input limits flexibility unnecessarily
+- Using abstract types for output makes it unclear what the caller will receive
+- Functions that accept only `list` can't be called with tuples or other sequences
+- Functions that return `Sequence` force callers to handle unknown concrete types
+
+## Correct Approach
+- **Input parameters**: Use abstract types (`Mapping`, `Sequence`, `Iterable`, etc.)
+  - Allows callers to pass any compatible type
+  - Follows the "be liberal in what you accept" principle
+- **Return types**: Use concrete types (`dict`, `list`, `set`, etc.)
+  - Makes it clear what the caller will receive
+  - Follows the "be conservative in what you return" principle
+
+## Examples
+
+### Bad
+```python
+# Too restrictive input - only accepts list
+def process_items(items: list[str]) -> list[str]:
+    return [item.upper() for item in items]
+
+# Too vague output - caller doesn't know concrete type
+from collections.abc import Sequence, Mapping
+
+def get_user_data(user_id: int) -> Mapping[str, str]:
+    return {"name": "John", "email": "john@example.com"}
+
+def filter_items(items: Sequence[int]) -> Sequence[int]:
+    return [x for x in items if x > 0]
+```
+
+### Good
+```python
+from collections.abc import Sequence, Mapping, Iterable
+
+# Abstract input, concrete output
+def process_items(items: Sequence[str]) -> list[str]:
+    return [item.upper() for item in items]
+
+def get_user_data(user_id: int) -> dict[str, str]:
+    return {"name": "John", "email": "john@example.com"}
+
+def filter_items(items: Iterable[int]) -> list[int]:
+    return [x for x in items if x > 0]
+
+# Now these all work:
+process_items(["a", "b", "c"])      # list
+process_items(("a", "b", "c"))      # tuple
+process_items(x for x in "abc")     # generator (with Iterable)
+```
+
+## Quick Reference
+
+| Input Type | Use For | Output Type |
+|------------|---------|-------------|
+| `Sequence[T]` | Ordered, indexable collections | `list[T]` |
+| `Mapping[K, V]` | Key-value mappings | `dict[K, V]` |
+| `Iterable[T]` | Any iterable (most flexible) | `list[T]` |
+| `Set[T]` / `AbstractSet[T]` | Unique collections | `set[T]` |
+| `MutableSequence[T]` | When mutation is needed | `list[T]` |
+| `MutableMapping[K, V]` | When mutation is needed | `dict[K, V]` |
+
+## Exceptions
+
+- When your function genuinely needs list-specific features (like `.append()` mutation), use `list` for input
+- When returning a view or iterator intentionally, use `Iterator` or appropriate abstract type
+- For APIs where backwards compatibility matters, be consistent with existing patterns


### PR DESCRIPTION
## Summary
This PR introduces a new "antipatterns" skill that documents common coding mistakes and bad practices to be avoided during code review and implementation. The skill serves as a reference guide for agents to prevent known issues and maintain code quality standards.

## Changes
- **New skill structure**: Created `skills/antipatterns/` directory with SKILL.md manifest
- **5 documented antipatterns**:
  - **AP-001**: Avoid `object` type in Python - use `typing.Any` or generics instead
  - **AP-002**: Don't modify pyproject.toml unnecessarily - use inline suppressions instead
  - **AP-003**: Use `collections.abc` for generic types - avoid deprecated `typing` imports
  - **AP-004**: Reuse existing enums - prevent duplicate enum definitions
  - **AP-005**: Always add unit tests for new features - ensure code reliability

## Implementation Details
- Each antipattern is documented in a separate markdown file with consistent structure:
  - Category classification
  - Clear description of the issue
  - Explanation of why it's problematic
  - Correct approach with best practices
  - Bad and good code examples
- The main SKILL.md provides an overview table and instructions for adding new antipatterns
- Patterns are designed to be automatically consulted during code review and implementation tasks
- Documentation includes practical examples and actionable guidance for developers

## Purpose
This skill enables agents to:
- Automatically catch common coding mistakes during code review
- Provide consistent guidance on best practices
- Reduce technical debt by preventing known antipatterns
- Serve as a living document that can be extended with new patterns as they're discovered

https://claude.ai/code/session_01PdaVzT8EPHNc2tyFvERDHd